### PR TITLE
Romanian language + Fix for weapon name/icon not reading sometimes

### DIFF
--- a/CS2_External/CS2_External.vcxproj
+++ b/CS2_External/CS2_External.vcxproj
@@ -194,6 +194,7 @@
     <ClInclude Include="Resources\Languages\Korean.h" />
     <ClInclude Include="Resources\Languages\Polish.h" />
     <ClInclude Include="Resources\Languages\Portuguese.h" />
+    <ClInclude Include="Resources\Languages\Romanian.h" />
     <ClInclude Include="Resources\Languages\Ruassian.h" />
     <ClInclude Include="Resources\Languages\SimplifiedChinese.h" />
     <ClInclude Include="Resources\Languages\Slovak.h" />

--- a/CS2_External/CS2_External.vcxproj.filters
+++ b/CS2_External/CS2_External.vcxproj.filters
@@ -190,6 +190,7 @@
     <ClInclude Include="Resources\Languages\Hungarian.h" />
     <ClInclude Include="Resources\Languages\Czech.h" />
     <ClInclude Include="Resources\Languages\Spanish.h" />
+    <ClInclude Include="Resources\Languages\Romanian.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="OS-ImGui\imgui\imgui.cpp">

--- a/CS2_External/Entity.cpp
+++ b/CS2_External/Entity.cpp
@@ -125,13 +125,13 @@ bool PlayerPawn::GetSpotted()
 bool PlayerPawn::GetWeaponName()
 {
 	DWORD64 WeaponNameAddress = 0;
-	char Buffer[40]{};
+	char Buffer[64]{};
 	
 	WeaponNameAddress = ProcessMgr.TraceAddress(this->Address + Offset::Pawn.pClippingWeapon, { 0x10,0x20 ,0x0 });
 	if (WeaponNameAddress == 0)
 		return false;
 
-	if (!ProcessMgr.ReadMemory(WeaponNameAddress, Buffer, 40))
+	if (!ProcessMgr.ReadMemory(WeaponNameAddress, Buffer, 64))
 		return false;
 
 	WeaponName = std::string(Buffer);

--- a/CS2_External/Features/GUI.h
+++ b/CS2_External/Features/GUI.h
@@ -410,7 +410,7 @@ namespace GUI
 					ImGui::TextDisabled(Lang::MiscText.LanguageList);
 					ImGui::SameLine();
 					if (ImGui::Combo("###Language", &MenuConfig::Language, 
-						"English\0Danish\0German\0Polish\0Portuguese\0Russian\0Simplified Chinese\0Slovak\0French\0Turkish\0Hungarian\0Dutch\0Cezch\0Spanish\0"))
+						"English\0Danish\0German\0Polish\0Portuguese\0Russian\0Simplified Chinese\0Slovak\0French\0Turkish\0Hungarian\0Dutch\0Cezch\0Spanish\0Romanian\0"))
 						Lang::ChangeLang(MenuConfig::Language);
 
 					ImGui::NewLine();

--- a/CS2_External/OS-ImGui/imgui/imgui_draw.cpp
+++ b/CS2_External/OS-ImGui/imgui/imgui_draw.cpp
@@ -3977,34 +3977,40 @@ const ImWchar*  ImFontAtlas::GetGlyphRangesChineseFull()
 
 const ImWchar* ImFontAtlas::GetGlyphRangesAll()
 {
-    static const ImWchar ranges[] =
-    {
-        0x0020, 0x00FF, // Basic Latin + Latin Supplement
-        0x0100, 0x017F, // Slovak and Polish
-        0x01A0, 0x01A1, // Vietnamese
-        0x01AF, 0x01B0, // Vietnamese
-        0x0370, 0x03FF, // Greek and Coptic
-        0x0400, 0x052F, // Cyrillic + Cyrillic Supplement
-        0x0E00, 0x0E7F, // Thai
-        0x0F00, 0x0FFF, // Tibetan
-        0x1100, 0x11FF, // Korean (Hangul Jamo)
-        0x1EA0, 0x1EF9, // Latin Extended
-        0x2000, 0x206F, // General Punctuation
-        0x2010, 0x205E, // Punctuations
-        0x2DE0, 0x2DFF, // Cyrillic Extended-A
-        0x3000, 0x30FF, // CJK Symbols and Punctuations, Hiragana, Katakana
-        0x3130, 0x318F, // Korean alphabets
-        0x31F0, 0x31FF, // Katakana Phonetic Extensions
-        0xAC00, 0xD7AF, // Korean characters
-        0xA640, 0xA69F, // Cyrillic Extended-B
-        0xA960, 0xA97F, // Koean characters Extended-A
-        0xD7B0, 0xD7FF, // Koean characters Extended-B
-        0xFF00, 0xFFEF, // Half-width characters
-        0xFFFD, 0xFFFD, // Invalid
-        0x4E00, 0x9FAF, // Chinese
-        0,
-    };
-    return &ranges[0];
+    static ImVector<ImWchar> ranges;
+    if (ranges.empty()) {
+        ImFontGlyphRangesBuilder builder;
+        static const ImWchar base_ranges[] =
+        {
+            0x0020, 0x00FF, // Basic Latin + Latin Supplement
+            0x0100, 0x017F, // Slovak and Polish
+            0x01A0, 0x01A1, // Vietnamese
+            0x01AF, 0x01B0, // Vietnamese
+            0x0300, 0x03FF, // Combining Diacritical Marks + Greek/Coptic
+            0x0400, 0x052F, // Cyrillic + Cyrillic Supplement
+            0x0E00, 0x0E7F, // Thai
+            0x0F00, 0x0FFF, // Tibetan
+            0x1100, 0x11FF, // Korean (Hangul Jamo)
+            0x1EA0, 0x1EF9, // Latin Extended
+            0x2000, 0x206F, // General Punctuation
+            0x2010, 0x205E, // Punctuations
+            0x2DE0, 0x2DFF, // Cyrillic Extended-A
+            0x3000, 0x30FF, // CJK Symbols and Punctuations, Hiragana, Katakana
+            0x3130, 0x318F, // Korean alphabets
+            0x31F0, 0x31FF, // Katakana Phonetic Extensions
+            0xAC00, 0xD7AF, // Korean characters
+            0xA640, 0xA69F, // Cyrillic Extended-B
+            0xA960, 0xA97F, // Koean characters Extended-A
+            0xD7B0, 0xD7FF, // Koean characters Extended-B
+            0xFF00, 0xFFEF, // Half-width characters
+            0xFFFD, 0xFFFD, // Invalid
+            0x4E00, 0x9FAF, // Chinese
+            0,
+        };
+        builder.AddRanges(base_ranges);
+        builder.BuildRanges(&ranges);
+    }
+    return ranges.Data;
 }
 
 static void UnpackAccumulativeOffsetsIntoRanges(int base_codepoint, const short* accumulative_offsets, int accumulative_offsets_count, ImWchar* out_ranges)

--- a/CS2_External/Resources/Language.cpp
+++ b/CS2_External/Resources/Language.cpp
@@ -14,6 +14,7 @@
 #include "Languages/Turkish.h"
 #include "Languages/Czech.h"
 #include "Languages/Spanish.h"
+#include "Languages/Romanian.h"
 
 namespace Lang
 {
@@ -65,6 +66,9 @@ namespace Lang
 			break;
 		case 13:
 			Spanish();
+			break;
+		case 14:
+			Romanian();
 			break;
 		default:
 			English();

--- a/CS2_External/Resources/Languages/Romanian.h
+++ b/CS2_External/Resources/Languages/Romanian.h
@@ -1,0 +1,146 @@
+﻿#pragma once
+#include "..\Language.h"
+namespace Lang
+{
+	inline void Czech()
+	{
+		Global.Date = u8"2024/01/19";
+		Global.Author = u8"Morfeusk";
+
+		Global.SwitchButton = u8"Aktivovat";
+		Global.FeatureSettings = u8"Nastavení";
+
+		// ESP
+		ESPtext.Toggle = u8"Toggle";
+		ESPtext.FeatureName = u8"RÁMEČEK";
+		ESPtext.Box = u8"Rámec";
+		ESPtext.BoxRounding = u8"Zaoblení rámu";
+		ESPtext.FilledBox = u8"Plný rámec";
+		ESPtext.FilledAlpha = u8"Průhlednost plného rámu";
+		ESPtext.Skeleton = u8"Kostlivec";
+		ESPtext.HeadBox = u8"Hlavní rámec";
+		ESPtext.EyeRay = u8"Ray očí";
+		ESPtext.HealthBar = u8"Zdravotní stav";
+		ESPtext.Weapon = u8"Zbraň";
+		ESPtext.Distance = u8"Vzdálenost";
+		ESPtext.PlayerName = u8"Jméno";
+		ESPtext.SnapLine = u8"Směrovka";
+		ESPtext.LinePosList = u8"Pozice čar";
+		ESPtext.VisCheck = u8"Viditelnost kontrola";
+		ESPtext.Preview = u8"Náhled okna rámce";
+		ESPtext.CollapseHead = u8"SexyRámec";
+		ESPtext.Penis = u8"Pulă";
+		ESPtext.PenisLength = u8"Lungimea pulii";
+		ESPtext.PenisSize = u8"Mărimea pulii";
+		ESPtext.MultiColor = u8"Více barev";
+		ESPtext.MultiColTip = u8"Funguje pouze pokud má rámeček nezaoblené rohy.";
+		ESPtext.Outline = u8"Outline";
+		ESPtext.BoxType = u8"Box Type:";
+		ESPtext.HealthNum = u8"Health Number";
+		ESPtext.Ammo = u8"Ammo";
+
+		ESPtext.BoxType_Normal = u8"Normal";
+		ESPtext.BoxType_Edge = u8"Dynamic";
+		ESPtext.BoxType_Corner = u8"Corner";
+		ESPtext.LinePos_1 = u8"Top";
+		ESPtext.LinePos_2 = u8"Center";
+		ESPtext.LinePos_3 = u8"Bottom";
+
+		// Aimbot
+		AimbotText.Enable = u8"Enable Aimbot";
+		AimbotText.FeatureName = u8"Automatické zaměřování";
+		AimbotText.HotKeyList = u8"Klávesa";
+		AimbotText.Toggle = u8"Zůstat zapnutý";
+		AimbotText.DrawFov = u8"Kreslit zorné pole";
+		AimbotText.VisCheck = u8"Pouze viditelný";
+		AimbotText.JumpCheck = u8"Pouze na zemi";
+		AimbotText.FovSlider = u8"Zorné pole";
+		AimbotText.SmoothSlider = u8"Hladkost";
+		AimbotText.BoneList = u8"Kost";
+		AimbotText.Tip = u8"Automatické zaměřování nefunguje s otevřeným oknem";
+
+		// Radar
+		RadarText.Toggle = u8"Radar";
+		RadarText.FeatureName = u8"Radar";
+		RadarText.StyleList = u8"Stiluri";
+		RadarText.CustomCheck = u8"Vlastní nastavení";
+		RadarText.CrossLine = u8"Křížová čára";
+		RadarText.SizeSlider = u8"Mărimea";
+		RadarText.ProportionSlider = u8"Proprție";
+		RadarText.RangeSlider = u8"Rază";
+		RadarText.AlphaSlider = u8"Alpha";
+
+		// Triggerbot
+		TriggerText.Enable = u8"Enable Triggerbot";
+		TriggerText.FeatureName = u8"Spouštěč střelby";
+		TriggerText.HotKeyList = u8"Zkratka";
+		TriggerText.Toggle = u8"Vždy aktivní";
+		TriggerText.DelaySlider = u8"Zpoždění střelby";
+		TriggerText.FakeShotSlider = u8"Délka střelby";
+
+		// Crosshairs
+		CrosshairsText.Toggle = u8"Show Crosshairs";
+		CrosshairsText.FeatureName = u8"Vlastní zaměřovač";
+		CrosshairsText.PresetList = u8"Předvolby";
+		CrosshairsText.ColorEditor = u8"Barva zaměřovače";
+		CrosshairsText.Dot = u8"Středový bod";
+		CrosshairsText.DotSizeSlider = u8"Velikost bodu";
+		CrosshairsText.Outline = u8"Obrys";
+		CrosshairsText.Crossline = u8"Křížová linka";
+		CrosshairsText.hLengthSlider = u8"Horizontální velikost";
+		CrosshairsText.vLengthSilder = u8"Vertikální velikost";
+		CrosshairsText.GapSlider = u8"Rozestup";
+		CrosshairsText.ThicknessSlider = u8"Tloušťka";
+		CrosshairsText.tStyle = u8"Styl T";
+		CrosshairsText.Circle = u8"Kruh";
+		CrosshairsText.RadiusSlider = u8"Poloměr kruhu";
+		CrosshairsText.TargetCheck = u8"Cílit na zaměřovač";
+		CrosshairsText.TeamCheck = u8"Kontrola týmu";
+
+		// Misc
+		MiscText.FeatureName = u8"Různé";
+		MiscText.ThemeList = u8"Téma";
+		MiscText.StyleList = u8"Styl";
+		MiscText.HeadshotLine = u8"Čáry na headshoty";
+		MiscText.SpecCheck = u8"Seznam3";
+		MiscText.NoFlash = u8"Bez blesku";
+		MiscText.HitSound = u8"Zvuk zásahu";
+		MiscText.bmbTimer = u8"Časový odpočet bomby";
+		MiscText.SpecList = u8"Seznam diváků";
+		MiscText.Bhop = u8"Skočit neustále";
+		MiscText.Watermark = u8"Zobrazit FPS";
+		MiscText.CheatList = u8"Seznam podvodů";
+		MiscText.TeamCheck = u8"Kontrola týmu";
+		MiscText.AntiRecord = u8"Neviditelný OBS Studio";
+		MiscText.MoneyService = u8"Money Services";
+		MiscText.ShowCashSpent = u8"Show Cash Spent";
+		MiscText.EnemySensor = u8"Enemy Sensor";
+		MiscText.RadarHack = u8"Radar Hack";
+		MiscText.FastStop = u8"Fast Stop";
+		MiscText.VisCheckDisable = u8"Visible Check DISABLED";
+
+		MiscText.FakeDuck = u8"Fake Duck";
+
+		MiscText.LanguageList = u8"Jazyk";
+
+		// Konfigurační menu
+		ConfigText.FeatureName = u8"Configurări";
+		ConfigText.MyConfigs = u8"Configurări";
+		ConfigText.Load = u8"Încarcă";
+		ConfigText.Save = u8"Salvează";
+		ConfigText.Delete = u8"Șterge";
+		ConfigText.Reset = u8"Restează";
+		ConfigText.Create = u8"Crează";
+		ConfigText.OpenFolder = u8"Deschide folderul";
+		ConfigText.SeparateLine = u8"Uložit konfiguraci";
+		ConfigText.AuthorName = u8"Autor";
+		ConfigText.ConfigName = u8"Configurare";
+
+		// Menu s informacemi
+		ReadMeText.FeatureName = u8"Přečtěte si mě";
+		ReadMeText.LastUpdate = u8"Poslední aktualizace: ";
+		ReadMeText.SourceButton = u8"Zdrojový kód";
+		ReadMeText.DiscordButton = u8"Připojit se k DISCORDU";
+		ReadMeText.OffsetsTitle = u8"Kompensace:";
+	}
+}

--- a/CS2_External/Resources/Languages/Romanian.h
+++ b/CS2_External/Resources/Languages/Romanian.h
@@ -2,126 +2,126 @@
 #include "..\Language.h"
 namespace Lang
 {
-	inline void Czech()
+	inline void Romanian()
 	{
-		Global.Date = u8"2024/01/19";
-		Global.Author = u8"Morfeusk";
+		Global.Date = u8"2024/01/23";
+		Global.Author = u8"JannesBonk :3";
 
-		Global.SwitchButton = u8"Aktivovat";
-		Global.FeatureSettings = u8"Nastavení";
+		Global.SwitchButton = u8"Activează";
+		Global.FeatureSettings = u8"Setări";
 
 		// ESP
-		ESPtext.Toggle = u8"Toggle";
-		ESPtext.FeatureName = u8"RÁMEČEK";
-		ESPtext.Box = u8"Rámec";
-		ESPtext.BoxRounding = u8"Zaoblení rámu";
-		ESPtext.FilledBox = u8"Plný rámec";
-		ESPtext.FilledAlpha = u8"Průhlednost plného rámu";
-		ESPtext.Skeleton = u8"Kostlivec";
-		ESPtext.HeadBox = u8"Hlavní rámec";
-		ESPtext.EyeRay = u8"Ray očí";
-		ESPtext.HealthBar = u8"Zdravotní stav";
-		ESPtext.Weapon = u8"Zbraň";
-		ESPtext.Distance = u8"Vzdálenost";
-		ESPtext.PlayerName = u8"Jméno";
-		ESPtext.SnapLine = u8"Směrovka";
-		ESPtext.LinePosList = u8"Pozice čar";
-		ESPtext.VisCheck = u8"Viditelnost kontrola";
-		ESPtext.Preview = u8"Náhled okna rámce";
-		ESPtext.CollapseHead = u8"SexyRámec";
+		ESPtext.Toggle = u8"Activează";
+		ESPtext.FeatureName = u8"ESP";
+		ESPtext.Box = u8"Ramă";
+		ESPtext.BoxRounding = u8"Rotunjirea cadrului";
+		ESPtext.FilledBox = u8"Umplerea cadrului";
+		ESPtext.FilledAlpha = u8"Alpha Umplerea cadrului";
+		ESPtext.Skeleton = u8"Schelet";
+		ESPtext.HeadBox = u8"Rama capului";
+		ESPtext.EyeRay = u8"Raza oculară";
+		ESPtext.HealthBar = u8"Bara de HP";
+		ESPtext.Weapon = u8"Armă";
+		ESPtext.Distance = u8"Distanță";
+		ESPtext.PlayerName = u8"Nume";
+		ESPtext.SnapLine = u8"Linie snap";
+		ESPtext.LinePosList = u8"Poziția linei snap";
+		ESPtext.VisCheck = u8"Verificarea vizibilități";
+		ESPtext.Preview = u8"Previzualizare";
+		ESPtext.CollapseHead = u8"ESP barbos";
 		ESPtext.Penis = u8"Pulă";
 		ESPtext.PenisLength = u8"Lungimea pulii";
 		ESPtext.PenisSize = u8"Mărimea pulii";
-		ESPtext.MultiColor = u8"Více barev";
-		ESPtext.MultiColTip = u8"Funguje pouze pokud má rámeček nezaoblené rohy.";
-		ESPtext.Outline = u8"Outline";
-		ESPtext.BoxType = u8"Box Type:";
-		ESPtext.HealthNum = u8"Health Number";
-		ESPtext.Ammo = u8"Ammo";
+		ESPtext.MultiColor = u8"Culori multiple";
+		ESPtext.MultiColTip = u8"Merge numai când rama n-are rotunjire";
+		ESPtext.Outline = u8"Contur";
+		ESPtext.BoxType = u8"Tipul ramei:";
+		ESPtext.HealthNum = u8"Număr HP";
+		ESPtext.Ammo = u8"Muniție";
 
 		ESPtext.BoxType_Normal = u8"Normal";
-		ESPtext.BoxType_Edge = u8"Dynamic";
-		ESPtext.BoxType_Corner = u8"Corner";
+		ESPtext.BoxType_Edge = u8"Dinamic";
+		ESPtext.BoxType_Corner = u8"Colțuri";
 		ESPtext.LinePos_1 = u8"Top";
-		ESPtext.LinePos_2 = u8"Center";
-		ESPtext.LinePos_3 = u8"Bottom";
+		ESPtext.LinePos_2 = u8"Centru";
+		ESPtext.LinePos_3 = u8"Jos";
 
 		// Aimbot
-		AimbotText.Enable = u8"Enable Aimbot";
-		AimbotText.FeatureName = u8"Automatické zaměřování";
-		AimbotText.HotKeyList = u8"Klávesa";
-		AimbotText.Toggle = u8"Zůstat zapnutý";
-		AimbotText.DrawFov = u8"Kreslit zorné pole";
-		AimbotText.VisCheck = u8"Pouze viditelný";
-		AimbotText.JumpCheck = u8"Pouze na zemi";
-		AimbotText.FovSlider = u8"Zorné pole";
-		AimbotText.SmoothSlider = u8"Hladkost";
-		AimbotText.BoneList = u8"Kost";
-		AimbotText.Tip = u8"Automatické zaměřování nefunguje s otevřeným oknem";
+		AimbotText.Enable = u8"Activează Aimbot";
+		AimbotText.FeatureName = u8"Aimbot";
+		AimbotText.HotKeyList = u8"Cheița";
+		AimbotText.Toggle = u8"Mod toggle";
+		AimbotText.DrawFov = u8"Arată FOV";
+		AimbotText.VisCheck = u8"Verificarea vizibilități";
+		AimbotText.JumpCheck = u8"Verificarea saltului";
+		AimbotText.FovSlider = u8"FOV";
+		AimbotText.SmoothSlider = u8"Finețe";
+		AimbotText.BoneList = u8"Hitbox-uri";
+		AimbotText.Tip = u8"Aimbot-ul merge numai când meniul este închis";
 
 		// Radar
 		RadarText.Toggle = u8"Radar";
 		RadarText.FeatureName = u8"Radar";
 		RadarText.StyleList = u8"Stiluri";
-		RadarText.CustomCheck = u8"Vlastní nastavení";
-		RadarText.CrossLine = u8"Křížová čára";
+		RadarText.CustomCheck = u8"Customizat";
+		RadarText.CrossLine = u8"Linie cross";
 		RadarText.SizeSlider = u8"Mărimea";
-		RadarText.ProportionSlider = u8"Proprție";
+		RadarText.ProportionSlider = u8"Proporție";
 		RadarText.RangeSlider = u8"Rază";
-		RadarText.AlphaSlider = u8"Alpha";
+		RadarText.AlphaSlider = u8"Alpha fereastră";
 
 		// Triggerbot
-		TriggerText.Enable = u8"Enable Triggerbot";
-		TriggerText.FeatureName = u8"Spouštěč střelby";
-		TriggerText.HotKeyList = u8"Zkratka";
-		TriggerText.Toggle = u8"Vždy aktivní";
-		TriggerText.DelaySlider = u8"Zpoždění střelby";
-		TriggerText.FakeShotSlider = u8"Délka střelby";
+		TriggerText.Enable = u8"Activeză Triggerbot";
+		TriggerText.FeatureName = u8"Triggerbot";
+		TriggerText.HotKeyList = u8"Cheița";
+		TriggerText.Toggle = u8"Mereu activ";
+		TriggerText.DelaySlider = u8"Întârziere";
+		TriggerText.FakeShotSlider = u8"Atac fals";
 
 		// Crosshairs
-		CrosshairsText.Toggle = u8"Show Crosshairs";
-		CrosshairsText.FeatureName = u8"Vlastní zaměřovač";
-		CrosshairsText.PresetList = u8"Předvolby";
-		CrosshairsText.ColorEditor = u8"Barva zaměřovače";
-		CrosshairsText.Dot = u8"Středový bod";
-		CrosshairsText.DotSizeSlider = u8"Velikost bodu";
-		CrosshairsText.Outline = u8"Obrys";
-		CrosshairsText.Crossline = u8"Křížová linka";
-		CrosshairsText.hLengthSlider = u8"Horizontální velikost";
-		CrosshairsText.vLengthSilder = u8"Vertikální velikost";
-		CrosshairsText.GapSlider = u8"Rozestup";
-		CrosshairsText.ThicknessSlider = u8"Tloušťka";
-		CrosshairsText.tStyle = u8"Styl T";
-		CrosshairsText.Circle = u8"Kruh";
-		CrosshairsText.RadiusSlider = u8"Poloměr kruhu";
-		CrosshairsText.TargetCheck = u8"Cílit na zaměřovač";
-		CrosshairsText.TeamCheck = u8"Kontrola týmu";
+		CrosshairsText.Toggle = u8"Arată crosshair";
+		CrosshairsText.FeatureName = u8"Crosshairs";
+		CrosshairsText.PresetList = u8"Presetări";
+		CrosshairsText.ColorEditor = u8"Culoare";
+		CrosshairsText.Dot = u8"Punct centrat";
+		CrosshairsText.DotSizeSlider = u8"Mărime punct";
+		CrosshairsText.Outline = u8"Contur";
+		CrosshairsText.Crossline = u8"Linie cross";
+		CrosshairsText.hLengthSlider = u8"Mărime orizontală";
+		CrosshairsText.vLengthSilder = u8"Mărime verticală";
+		CrosshairsText.GapSlider = u8"Mărime gaură";
+		CrosshairsText.ThicknessSlider = u8"Grosime";
+		CrosshairsText.tStyle = u8"Stil T";
+		CrosshairsText.Circle = u8"Cerc";
+		CrosshairsText.RadiusSlider = u8"Rază cerc:";
+		CrosshairsText.TargetCheck = u8"Previzualizare țintă";
+		CrosshairsText.TeamCheck = u8"Verificarea echipei";
 
 		// Misc
 		MiscText.FeatureName = u8"Různé";
-		MiscText.ThemeList = u8"Téma";
-		MiscText.StyleList = u8"Styl";
-		MiscText.HeadshotLine = u8"Čáry na headshoty";
-		MiscText.SpecCheck = u8"Seznam3";
-		MiscText.NoFlash = u8"Bez blesku";
-		MiscText.HitSound = u8"Zvuk zásahu";
-		MiscText.bmbTimer = u8"Časový odpočet bomby";
-		MiscText.SpecList = u8"Seznam diváků";
-		MiscText.Bhop = u8"Skočit neustále";
-		MiscText.Watermark = u8"Zobrazit FPS";
-		MiscText.CheatList = u8"Seznam podvodů";
-		MiscText.TeamCheck = u8"Kontrola týmu";
-		MiscText.AntiRecord = u8"Neviditelný OBS Studio";
-		MiscText.MoneyService = u8"Money Services";
-		MiscText.ShowCashSpent = u8"Show Cash Spent";
-		MiscText.EnemySensor = u8"Enemy Sensor";
-		MiscText.RadarHack = u8"Radar Hack";
-		MiscText.FastStop = u8"Fast Stop";
-		MiscText.VisCheckDisable = u8"Visible Check DISABLED";
+		MiscText.ThemeList = u8"Temă";
+		MiscText.StyleList = u8"Stil";
+		MiscText.HeadshotLine = u8"Linie headshot";
+		MiscText.SpecCheck = u8"Verificare spectator";
+		MiscText.NoFlash = u8"Fără flash";
+		MiscText.HitSound = u8"Hitsound";
+		MiscText.bmbTimer = u8"Cronometru bombă";
+		MiscText.SpecList = u8"Listă spectatori";
+		MiscText.Bhop = u8"Bunnyhop";
+		MiscText.Watermark = u8"Filigran";
+		MiscText.CheatList = u8"Listă hackuri";
+		MiscText.TeamCheck = u8"Verificarea echipei";
+		MiscText.AntiRecord = u8"Anti captură";
+		MiscText.MoneyService = u8"Serviciu bani";
+		MiscText.ShowCashSpent = u8"Arată banii cheltuiți";
+		MiscText.EnemySensor = u8"Senzor inamic";
+		MiscText.RadarHack = u8"Radar hack";
+		MiscText.FastStop = u8"Stop rapid";
+		MiscText.VisCheckDisable = u8"Verificarea vizibilități OFF";
 
-		MiscText.FakeDuck = u8"Fake Duck";
+		MiscText.FakeDuck = u8"Chrouch fals";
 
-		MiscText.LanguageList = u8"Jazyk";
+		MiscText.LanguageList = u8"Limba";
 
 		// Konfigurační menu
 		ConfigText.FeatureName = u8"Configurări";
@@ -132,15 +132,15 @@ namespace Lang
 		ConfigText.Reset = u8"Restează";
 		ConfigText.Create = u8"Crează";
 		ConfigText.OpenFolder = u8"Deschide folderul";
-		ConfigText.SeparateLine = u8"Uložit konfiguraci";
+		ConfigText.SeparateLine = u8"Nou";
 		ConfigText.AuthorName = u8"Autor";
 		ConfigText.ConfigName = u8"Configurare";
 
 		// Menu s informacemi
-		ReadMeText.FeatureName = u8"Přečtěte si mě";
-		ReadMeText.LastUpdate = u8"Poslední aktualizace: ";
-		ReadMeText.SourceButton = u8"Zdrojový kód";
-		ReadMeText.DiscordButton = u8"Připojit se k DISCORDU";
-		ReadMeText.OffsetsTitle = u8"Kompensace:";
+		ReadMeText.FeatureName = u8"Citeștemă";
+		ReadMeText.LastUpdate = u8"Ultimul update: ";
+		ReadMeText.SourceButton = u8"Sursă cod";
+		ReadMeText.DiscordButton = u8"Discord server";
+		ReadMeText.OffsetsTitle = u8"Offset-uri:";
 	}
 }


### PR DESCRIPTION
- Added romanian language
- Made ``GetGlyphRangesAll()`` work
- Fix for weapon name/icon not reading sometimes (cuz of the new update, weapons such as XM1014, SG556 or SSG08 wouldn't get read by the cheat)
