### PR TITLE
add aimbot min fov setting

### DIFF
--- a/CS2_External/AimBot.hpp
+++ b/CS2_External/AimBot.hpp
@@ -21,6 +21,7 @@ namespace AimControl
     inline bool AutoShot = false;
     inline bool AimLock = false;
     inline float AimFov = 5;
+    inline float AimFovMin = .5f;
     inline float Smooth = 2.0f;
     inline Vec2 RCSScale = { 1.f,1.f };
     inline std::vector<int> HotKeyList{ VK_LMENU, VK_LBUTTON, VK_RBUTTON, VK_XBUTTON1, VK_XBUTTON2, VK_CAPITAL, VK_LSHIFT, VK_LCONTROL };
@@ -97,7 +98,7 @@ namespace AimControl
         Vec2 ScreenPos;
         gGame.View.WorldToScreen(Vec3(AimPos), ScreenPos);
 
-        if (Norm < AimFov)
+        if (Norm < AimFov && Norm > AimFovMin)
         {
             // Shake Fixed by @Sweely
             if (ScreenPos.x != ScreenCenterX)

--- a/CS2_External/Features/GUI.h
+++ b/CS2_External/Features/GUI.h
@@ -338,6 +338,7 @@ namespace GUI
 						PutSwitch(Lang::AimbotText.ScopeOnly, 10.f, ImGui::GetFrameHeight() * 1.7, &AimControl::ScopeOnly);
 						PutSwitch(Lang::AimbotText.AutoShot, 10.f, ImGui::GetFrameHeight() * 1.7, &AimControl::AutoShot);
 						PutSliderFloat(Lang::AimbotText.FovSlider, 10.f, &AimControl::AimFov, &FovMin, &FovMax, "%.1f");
+						PutSliderFloat(Lang::AimbotText.FovMinSlider, 10.f, &AimControl::AimFovMin, &FovMin, &FovMax, "%.1f");
 						PutSliderFloat(Lang::AimbotText.SmoothSlider, 10.f, &AimControl::Smooth, &SmoothMin, &SmoothMax, "%.1f");
 						ImGui::SetCursorPosX(ImGui::GetCursorPosX() + 10.f);
 						ImGui::TextDisabled(Lang::AimbotText.BoneList);

--- a/CS2_External/Resources/Language.h
+++ b/CS2_External/Resources/Language.h
@@ -68,6 +68,7 @@ namespace Lang
 		inline static const char* VisCheck;
 		inline static const char* JumpCheck;
 		inline static const char* FovSlider;
+		inline static const char* FovMinSlider;
 		inline static const char* SmoothSlider;
 		inline static const char* BoneList;
 		inline static const char* Tip;

--- a/CS2_External/Resources/Language.h
+++ b/CS2_External/Resources/Language.h
@@ -247,6 +247,7 @@ namespace Lang
 		AimbotText.VisCheck = u8"Visible Only";
 		AimbotText.JumpCheck = u8"On Ground Only";
 		AimbotText.FovSlider = u8"FOV: ";
+		AimbotText.FovMinSlider = u8"MinFOV: ";
 		AimbotText.SmoothSlider = u8"Smooth: ";
 		AimbotText.BoneList = u8"Bone       ";
 		AimbotText.Tip = u8"Aimbot will not work while the menu is opened";

--- a/CS2_External/Resources/Languages/SimplifiedChinese.h
+++ b/CS2_External/Resources/Languages/SimplifiedChinese.h
@@ -59,6 +59,7 @@ namespace Lang
 		AimbotText.VisCheck = u8"仅可见目标";
 		AimbotText.JumpCheck = u8"仅在地面上";
 		AimbotText.FovSlider = u8"FOV: ";
+		AimbotText.FovMinSlider = u8"最小FOV: ";
 		AimbotText.SmoothSlider = u8"平滑度: ";
 		AimbotText.BoneList = u8"瞄准部位  ";
 		AimbotText.Tip = u8"此功能在菜单打开时不会工作";

--- a/CS2_External/Utils/ConfigSaver.cpp
+++ b/CS2_External/Utils/ConfigSaver.cpp
@@ -255,6 +255,7 @@ namespace MyConfigSaver {
         emitter << YAML::Key << "ToggleMode" << YAML::Value << MenuConfig::AimToggleMode;
         emitter << YAML::Key << "Hotkey" << YAML::Value << MenuConfig::AimBotHotKey;
         emitter << YAML::Key << "Fov" << YAML::Value << AimControl::AimFov;
+        emitter << YAML::Key << "FovMin" << YAML::Value << AimControl::AimFovMin;
         emitter << YAML::Key << "FovCircle" << YAML::Value << ESPConfig::DrawFov;
         emitter << YAML::Key << "CircleColor";
         emitter << YAML::Value;
@@ -452,6 +453,7 @@ namespace MyConfigSaver {
             MenuConfig::AimToggleMode = config["Aimbot"]["ToggleMode"].as<bool>();
             MenuConfig::AimBotHotKey = config["Aimbot"]["Hotkey"].as<int>();
             AimControl::AimFov = config["Aimbot"]["Fov"].as<float>();
+            AimControl::AimFovMin = config["Aimbot"]["FovMin"].as<float>();
             ESPConfig::DrawFov = config["Aimbot"]["FovCircle"].as<bool>();
             MenuConfig::FovCircleColor.Value.x = config["Aimbot"]["CircleColor"]["r"].as<float>();
             MenuConfig::FovCircleColor.Value.y = config["Aimbot"]["CircleColor"]["g"].as<float>();


### PR DESCRIPTION
Avoid glitch after aiming when set smooth low by setting the minimum target fov for aimbot
The working principle can be understood as joystick Deadzone

this might remain bugs ?¿since only tested via remote desktop

对不起脑姐，本来想睡觉的，睡了一小时又醒了决定粘贴完再睡😉