### PR TITLE
Fix Winne ESP Bug for non Chinese user

### DIFF
--- a/CS2_External/Features/GUI.h
+++ b/CS2_External/Features/GUI.h
@@ -438,10 +438,13 @@ namespace GUI
 						ImGui::SetCursorPosX(ImGui::GetCursorPosX() + 10.f);
 						ImGui::TextColored(ImColor(255, 50, 0, 255), "This might cause BAN");
 					}
-					if (MenuConfig::Country == "CN" && MenuConfig::Language == 6)
+					if (MenuConfig::Country == "CN" && MenuConfig::Language == 6 && ESPConfig::winniethepool)
 					{
-						ESPConfig::winniethepool = true;
 						PutSwitch("Winnie", 10.f, ImGui::GetFrameHeight() * 1.7, &ESPConfig::winniethepool);
+					}
+					else
+					{
+						ESPConfig::winniethepool = false;
 					}
 
 

--- a/CS2_External/Features/GUI.h
+++ b/CS2_External/Features/GUI.h
@@ -438,8 +438,11 @@ namespace GUI
 						ImGui::SetCursorPosX(ImGui::GetCursorPosX() + 10.f);
 						ImGui::TextColored(ImColor(255, 50, 0, 255), "This might cause BAN");
 					}
-					if (MenuConfig::Country == "CN" && ESPConfig::winniethepool && MenuConfig::Language == 6)
+					if (MenuConfig::Country == "CN" && MenuConfig::Language == 6)
+					{
+						ESPConfig::winniethepool = true;
 						PutSwitch("Winnie", 10.f, ImGui::GetFrameHeight() * 1.7, &ESPConfig::winniethepool);
+					}
 
 
 					ImGui::NextColumn();

--- a/CS2_External/MenuConfig.hpp
+++ b/CS2_External/MenuConfig.hpp
@@ -84,7 +84,7 @@ namespace ESPConfig
 	inline bool ShowScoping = false;
 	inline bool ShowBoneESP = true;
 	inline bool ShowBoxESP = true;
-	inline bool winniethepool = true;
+	inline bool winniethepool = false;
 	inline bool ShowHealthBar = true;
 	inline bool ShowWeaponESP = false;
 	inline bool ShowEyeRay = false;

--- a/CS2_External/MenuConfig.hpp
+++ b/CS2_External/MenuConfig.hpp
@@ -84,7 +84,7 @@ namespace ESPConfig
 	inline bool ShowScoping = false;
 	inline bool ShowBoneESP = true;
 	inline bool ShowBoxESP = true;
-	inline bool winniethepool = false;
+	inline bool winniethepool = true;
 	inline bool ShowHealthBar = true;
 	inline bool ShowWeaponESP = false;
 	inline bool ShowEyeRay = false;


### PR DESCRIPTION
Solved the issue that non Chinese users enable winnie ESP by default but do not have the switch to turn it off. 
at the same time, keep this feature enabled by default for sino users 😉