### PR TITLE
Add Toggle Key to ESP

### DIFF
--- a/CS2_External/Backup/Languages/Czech.h
+++ b/CS2_External/Backup/Languages/Czech.h
@@ -11,7 +11,9 @@ namespace Lang
 		Global.FeatureSettings = u8"Nastavení";
 
 		// ESP
-		ESPtext.Toggle = u8"Toggle";
+		ESPtext.Enable = u8"Enable ESP";
+		ESPtext.Hotkey = u8"Klávesa";
+		ESPtext.AlwaysActive = u8"Vždy aktivní";
 		ESPtext.FeatureName = u8"RÁMEČEK";
 		ESPtext.Box = u8"Rámec";
 		ESPtext.BoxRounding = u8"Zaoblení rámu";

--- a/CS2_External/Backup/Languages/Danish.h
+++ b/CS2_External/Backup/Languages/Danish.h
@@ -11,6 +11,9 @@ namespace Lang
 		Global.FeatureSettings = u8"Indstillinger";
 
 		// ESP
+		ESPtext.Enable = u8"Enable ESP";
+		ESPtext.Hotkey = u8"Nøgle";
+		ESPtext.AlwaysActive = u8"Altid aktiv";
 		ESPtext.FeatureName = u8" ESP";
 		ESPtext.Box = u8"Boks";
 		ESPtext.BoxRounding = u8"Boks Runding";

--- a/CS2_External/Backup/Languages/Dutch.h
+++ b/CS2_External/Backup/Languages/Dutch.h
@@ -11,6 +11,9 @@ namespace Lang
 		Global.FeatureSettings = u8"Instellingen";
 
 		// ESP
+		ESPtext.Enable = u8"Aan ESP";
+		ESPtext.Hotkey = u8"Sneltoets";
+		ESPtext.AlwaysActive = u8"Altijd actief";
 		ESPtext.FeatureName = u8" ESP";
 		ESPtext.Box = u8"Omlijning";
 		ESPtext.BoxRounding = u8"Omlijning Afronding";

--- a/CS2_External/Backup/Languages/English.h
+++ b/CS2_External/Backup/Languages/English.h
@@ -11,7 +11,9 @@ namespace Lang
 		Global.FeatureSettings = u8"Settings";
 
 		// ESP
-		ESPtext.Toggle = u8"Toggle";
+		ESPtext.Enable = u8"Enable ESP";
+		ESPtext.Hotkey = u8"Hotkey";
+		ESPtext.AlwaysActive = u8"Always Active";
 		ESPtext.FeatureName = u8" ESP";
 		ESPtext.Box = u8"Frame";
 		ESPtext.BoxRounding = u8"Box Rounding: ";

--- a/CS2_External/Backup/Languages/Francais.h
+++ b/CS2_External/Backup/Languages/Francais.h
@@ -11,7 +11,9 @@ namespace Lang
 		Global.FeatureSettings = u8"Parametres";
 
 		// ESP
-		ESPtext.Toggle = u8"basculer";
+		ESPtext.Enable = u8"Basculer ESP";
+		ESPtext.Hotkey = u8"Touche d'activation";
+		ESPtext.AlwaysActive = u8"Tout le temps";
 		ESPtext.FeatureName = u8" Hack des boxs";
 		ESPtext.Box = u8"portrait";
 		ESPtext.BoxRounding = u8"Boite arrondie: ";

--- a/CS2_External/Backup/Languages/German.h
+++ b/CS2_External/Backup/Languages/German.h
@@ -10,6 +10,9 @@ namespace Lang
 		Global.FeatureSettings = u8"Settings";
 
 		// ESP
+		ESPtext.Enable = u8"ESP einschalten";
+		ESPtext.Hotkey = u8"Hotkey";
+		ESPtext.AlwaysActive = u8"Immer aktiv";
 		ESPtext.FeatureName = u8" ESP";
 		ESPtext.Box = u8"Box";
 		ESPtext.BoxRounding = u8"Kasten rundung";

--- a/CS2_External/Backup/Languages/Greek.h
+++ b/CS2_External/Backup/Languages/Greek.h
@@ -11,7 +11,9 @@ namespace Lang
 		Global.FeatureSettings = u8"Ρυθμίσεις";
 
 		// ESP
-		ESPtext.Toggle = u8"Εναλλαγή";
+		ESPtext.Enable = u8"Ενεργοποίηση ESP";
+		ESPtext.Hotkey = u8"Hotkey";
+		ESPtext.AlwaysActive = u8"Πάντα ενεργό";
 		ESPtext.FeatureName = u8" ESP";
 		ESPtext.Box = u8"Πλαίσιο";
 		ESPtext.BoxRounding = u8"Στρογγυλοποίηση Κουτιού: ";

--- a/CS2_External/Backup/Languages/Hungarian.h
+++ b/CS2_External/Backup/Languages/Hungarian.h
@@ -11,6 +11,9 @@ namespace Lang
 		Global.FeatureSettings = u8"Beállítások";
 
 		// ESP
+		ESPtext.Enable = u8"ESP engedélyezése";
+		ESPtext.Hotkey = u8"Hotkey";
+		ESPtext.AlwaysActive = u8"Mindig aktív";
 		ESPtext.FeatureName = u8"Extraszenzoros észlelés";
 		ESPtext.Box = u8"Doboz";
 		ESPtext.BoxRounding = u8"Doboz kerekítés";

--- a/CS2_External/Backup/Languages/Korean.h
+++ b/CS2_External/Backup/Languages/Korean.h
@@ -11,6 +11,9 @@ namespace Lang
 		Global.FeatureSettings = u8"설정";
 
 		// ESP
+		ESPtext.Enable = u8"ESP 사용";
+		ESPtext.Hotkey = u8"핫키";
+		ESPtext.AlwaysActive = u8"항상 활성화";
 		ESPtext.FeatureName = u8" 이에스피 ";
 		ESPtext.Box = u8"박스";
 		ESPtext.BoxRounding = u8"박스 랜더링";

--- a/CS2_External/Backup/Languages/Polish.h
+++ b/CS2_External/Backup/Languages/Polish.h
@@ -13,6 +13,9 @@ namespace Lang
 		Global.FeatureSettings = u8"Ustawienia";
 
 		// ESP
+		ESPtext.Enable = u8"Włącz ESP";
+		ESPtext.Hotkey = u8"Klawisz skrótu";
+		ESPtext.AlwaysActive = u8"Zawsze aktywny";
 		ESPtext.FeatureName = u8" ESP";
 		ESPtext.Box = u8"Box";
 		ESPtext.BoxRounding = u8"Zaokrąglenie Boxa";

--- a/CS2_External/Backup/Languages/Portuguese.h
+++ b/CS2_External/Backup/Languages/Portuguese.h
@@ -11,6 +11,9 @@ namespace Lang
 		Global.FeatureSettings = u8"Definições";
 
 		// ESP
+		ESPtext.Enable = u8"Ativar ESP";
+		ESPtext.Hotkey = u8"Tecla de atalho";
+		ESPtext.AlwaysActive = u8"Sempre ativo";
 		ESPtext.FeatureName = u8" ESP";
 		ESPtext.Box = u8"Caixa";
 		ESPtext.BoxRounding = u8"Borda da Caixa";

--- a/CS2_External/Backup/Languages/Romanian.h
+++ b/CS2_External/Backup/Languages/Romanian.h
@@ -11,7 +11,9 @@ namespace Lang
 		Global.FeatureSettings = u8"Setări";
 
 		// ESP
-		ESPtext.Toggle = u8"Activează";
+		ESPtext.Enable = u8"Activează ESP";
+		ESPtext.Hotkey = u8"Hotkey";
+		ESPtext.AlwaysActive = u8"Întotdeauna activă";
 		ESPtext.FeatureName = u8"ESP";
 		ESPtext.Box = u8"Ramă";
 		ESPtext.BoxRounding = u8"Rotunjirea cadrului";

--- a/CS2_External/Backup/Languages/Ruassian.h
+++ b/CS2_External/Backup/Languages/Ruassian.h
@@ -12,7 +12,9 @@ namespace Lang
 		Global.FeatureSettings = u8"Настройки";
 
 		// ESP
-		ESPtext.Toggle = u8"Toggle";
+		ESPtext.Enable = u8"Включить ESP";
+		ESPtext.Hotkey = u8"Горячая клавиша";
+		ESPtext.AlwaysActive = u8"Всегда активна";
 		ESPtext.FeatureName = u8" ESP (WH)";
 		ESPtext.Box = u8"Обводка";
 		ESPtext.BoxRounding = u8"Округление обводки";

--- a/CS2_External/Backup/Languages/SimplifiedChinese.h
+++ b/CS2_External/Backup/Languages/SimplifiedChinese.h
@@ -11,7 +11,9 @@ namespace Lang
 		Global.FeatureSettings = u8"详细设置";
 
 		// ESP
-		ESPtext.Toggle = u8"总开关";
+		ESPtext.Enable = u8"启用 ESP";
+		ESPtext.Hotkey = u8"热键";
+		ESPtext.AlwaysActive = u8"始终激活";
 		ESPtext.FeatureName = u8" ESP";
 		ESPtext.Box = u8"方框";
 		ESPtext.BoxRounding = u8"圆角化:";

--- a/CS2_External/Backup/Languages/Slovak.h
+++ b/CS2_External/Backup/Languages/Slovak.h
@@ -13,6 +13,9 @@ namespace Lang
 		Global.FeatureSettings = u8"Nastavenia";
 
 		// ESP
+		ESPtext.Enable = u8"Povolenie ESP";
+		ESPtext.Hotkey = u8"Klávesová skratka";
+		ESPtext.AlwaysActive = u8"Vždy aktívne";
 		ESPtext.FeatureName = u8" ESP";
 		ESPtext.Box = u8"Box";
 		ESPtext.BoxRounding = u8"Zaoblenie Boxu";

--- a/CS2_External/Backup/Languages/Spanish.h
+++ b/CS2_External/Backup/Languages/Spanish.h
@@ -11,7 +11,9 @@ namespace Lang
 		Global.FeatureSettings = u8"Ajustes detallados";
 
 		// ESP
-		ESPtext.Toggle = u8"interruptor principal";
+		ESPtext.Enable = u8"Activar ESP";
+		ESPtext.Hotkey = u8"Tecla de acceso rápido";
+		ESPtext.AlwaysActive = u8"Siempre activa";
 		ESPtext.FeatureName = u8" ESP";	
 		ESPtext.Box = u8"cajas";
 		ESPtext.BoxRounding = u8"redondeo:";

--- a/CS2_External/Backup/Languages/Turkish.h
+++ b/CS2_External/Backup/Languages/Turkish.h
@@ -11,6 +11,9 @@ namespace Lang
 		Global.FeatureSettings = u8"Ayarlar";
 
 		// ESP
+		ESPtext.Enable = u8"ESP'yi Etkinleştir";
+		ESPtext.Hotkey = u8"Kısayol Tuşu";
+		ESPtext.AlwaysActive = u8"Her zaman aktif";
 		ESPtext.FeatureName = u8" Görüş Hilesi";
 		ESPtext.Box = u8"Çerçeve";
 		ESPtext.BoxRounding = u8"Köşe Yuvarlaklığı";

--- a/CS2_External/Cheats.cpp
+++ b/CS2_External/Cheats.cpp
@@ -384,14 +384,28 @@ void Cheats::Run() noexcept
 				}
 			}
 
-			if (ESPConfig::ESPenabled)
-			{
-				std::thread tESP(Cheats::RenderESP,Entity, EntityAddress, LocalEntity, LocalPlayerControllerIndex, index);
-				
-				tESP.join();
-			}
-			Glow::Run(Entity);
+			// Check if ESP should be rendered based on hotkey state
+			if (ESPConfig::ESPenabled && GetAsyncKeyState(ESP::HotKey) & 0x8000 || ESPConfig::AlwaysActive) {
+				bool renderSuccess = false;
+				const int maxRetries = 3; // Maximum retries for rendering
+				for (int attempt = 0; attempt < maxRetries; ++attempt) {
+					try {
+						Cheats::RenderESP(Entity, EntityAddress, LocalEntity, LocalPlayerControllerIndex, index);
+						renderSuccess = true;
+						break; // Exit if rendering was successful
+					}
+					catch (...) {
+						std::this_thread::sleep_for(std::chrono::milliseconds(100)); // Optional delay before retrying
+					}
+				}
 
+				// Optionally handle the case where rendering continuously fails
+				if (!renderSuccess) {
+					// Handle failed rendering if necessary; you might want to log or print something here
+				}
+			}
+
+			Glow::Run(Entity);
 		}
 
 		// Aimbot

--- a/CS2_External/Features/ESP.h
+++ b/CS2_External/Features/ESP.h
@@ -12,6 +12,7 @@ int winnie_h = 0, winnie_w = 0;
 
 namespace ESP
 {
+	inline unsigned int HotKey = VK_XBUTTON2;
 	struct WeaponIconSize
 	{
 		float width;

--- a/CS2_External/Features/GUI.h
+++ b/CS2_External/Features/GUI.h
@@ -440,11 +440,16 @@ namespace GUI
 					float MinRounding = 0.f, MaxRouding = 5.f;
 					int MinCombo = 0, MaxCombo = 2;
 					int MinDis = 0, MaxDis = 128;
-					PutSwitch(Lang::ESPtext.Toggle, 10.f, ImGui::GetFrameHeight() * 1.7, &ESPConfig::ESPenabled);
+					PutSwitch(Lang::ESPtext.Enable, 10.f, ImGui::GetFrameHeight() * 1.7, &ESPConfig::ESPenabled);
 					if (ESPConfig::ESPenabled)
 					{
 						const char* BoxTypes[] = { Lang::ESPtext.BoxType_Normal, Lang::ESPtext.BoxType_Edge, Lang::ESPtext.BoxType_Corner };
 						const char* LinePos[] = { Lang::ESPtext.LinePos_1, Lang::ESPtext.LinePos_2, Lang::ESPtext.LinePos_3 };
+						ImGui::SetCursorPosX(ImGui::GetCursorPosX() + 10.f);
+						ImGui::TextDisabled(Lang::ESPtext.Hotkey);
+						ImGui::SameLine();
+						ImGui::HotKey("Hotkey##esphotkey", &ESP::HotKey);
+						PutSwitch(Lang::ESPtext.AlwaysActive, 10.f, ImGui::GetFrameHeight() * 1.7, &ESPConfig::AlwaysActive);
 						PutSwitch(Lang::ESPtext.Box, 10.f, ImGui::GetFrameHeight() * 1.7, &ESPConfig::ShowBoxESP, true, "###BoxCol", reinterpret_cast<float*>(&ESPConfig::BoxColor));
 						if (ESPConfig::ShowBoxESP)
 						{

--- a/CS2_External/MenuConfig.hpp
+++ b/CS2_External/MenuConfig.hpp
@@ -99,6 +99,7 @@ namespace MenuConfig
 namespace ESPConfig
 {
 	inline bool ESPenabled = true;
+	inline bool AlwaysActive = false;
 	inline bool AmmoBar = false;
 	inline bool ShowScoping = false;
 	inline bool ShowBoneESP = true;

--- a/CS2_External/Resources/Language.h
+++ b/CS2_External/Resources/Language.h
@@ -34,7 +34,9 @@ namespace Lang
 
 	inline struct ESPtext
 	{
-		inline static const char* Toggle;
+		inline static const char* Enable;
+		inline static const char* Hotkey;
+		inline static const char* AlwaysActive;
 		inline static const char* FeatureName;
 		inline static const char* Box;
 		inline static const char* BoxRounding;
@@ -237,7 +239,9 @@ namespace Lang
 		Global.FeatureSettings ="Settings";
 
 		// ESP
-		ESPtext.Toggle ="Toggle";
+		ESPtext.Enable ="Enable ESP";
+		ESPtext.Hotkey ="Hotkey";
+		ESPtext.AlwaysActive ="Always Active";
 		ESPtext.FeatureName =" ESP";
 		ESPtext.Box ="Frame";
 		ESPtext.BoxRounding ="Box Rounding: ";


### PR DESCRIPTION
**Summary**
This PR introduces a new toggle key (hotkey) and an "Always Active" switch for the ESP. Additionally, I have translated the following terms into all available languages.

**Preview**
![Screenshot 2024-10-14 131904](https://github.com/user-attachments/assets/cbd5876f-54b2-40e5-8b9b-feca958b273a)

**Changes Made**

- **Toggle Key/Hotkey**: Users can now activate/deactivate ESP using a configurable key.

- **Always Active Switch**: A new option that allows users to keep the ESP feature active without needing to toggle it manually.

- **Translation**: Added translations for "Enable ESP," "Hotkey," and "Always Active" to ensure users can access these features in their preferred language.

**Motivation**
I believe these changes will really enhance how players use the ESP feature. With the new toggle and "Always Active" option, it’s super convenient to check where other players are, see their health, and find out what weapons they have just by quickly activating the ESP. Plus, being able to turn it off while you’re playing helps you stay under the radar and feel more natural in your gameplay.

Thank you for considering this update! I look forward to your feedback.